### PR TITLE
Add Mapforge to not found app suggestions

### DIFF
--- a/src/app/ui/components/NotFoundApps.tsx
+++ b/src/app/ui/components/NotFoundApps.tsx
@@ -5,6 +5,7 @@ import { AppCompact } from "@components/common/AppCompact";
 
 const notFoundAppsTitle = [
   "MapComplete",
+  "Mapforge",
   "uMap",
   "OpenStreetBrowser",
   "Overpass turbo",


### PR DESCRIPTION
## Summary
- Add Mapforge to the "Not found what you are looking for?" suggestion list.
- Place it between MapComplete and uMap, matching #333.

Fixes #333.

## Testing
- `git diff --check`

Note: `npm ci` did not complete locally because the current `package-lock.json` is missing entries for `@emnapi/core@1.11.0` and `@emnapi/runtime@1.11.0`, and my local Node v26.2.0 is outside `@github/local-action` engine range `^20 || ^22 || ^24`.